### PR TITLE
Fixes topn, MODEL_TO_CLASS, args.docfreq

### DIFF
--- a/ast2vec/model2/source2bow.py
+++ b/ast2vec/model2/source2bow.py
@@ -51,7 +51,7 @@ class Uasts2BOW:
 
 class UastModel2BOW(Model2Base):
     MODEL_FROM_CLASS = UASTModel
-    MODEL_TO_CLASS = UASTModel
+    MODEL_TO_CLASS = BOW
 
     def __init__(self, topn, docfreq, *args, **kwargs):
         super(UastModel2BOW, self).__init__(*args, **kwargs)
@@ -61,7 +61,8 @@ class UastModel2BOW(Model2Base):
         for i, (k, v) in enumerate(docfreq):
             freqs[i] = -v
             vocabulary[i] = k
-        indices = freqs.argpartition(topn)[:topn]
+        topn = min(topn, len(freqs))
+        indices = freqs.argpartition(topn-1)[:topn]
         freqs = freqs[indices]
         vocabulary = [vocabulary[i] for i in indices]
         indices = freqs.argsort()
@@ -82,7 +83,7 @@ class UastModel2BOW(Model2Base):
 
 
 def source2bow_entry(args):
-    df = DocumentFrequencies().load(args.df)
+    df = DocumentFrequencies().load(args.docfreq)
     os.makedirs(args.output, exist_ok=True)
     converter = UastModel2BOW(args.vocabulary_size, df, num_processes=args.processes)
     converter.convert(args.input, args.output, pattern=args.filter)

--- a/ast2vec/model2/source2df.py
+++ b/ast2vec/model2/source2df.py
@@ -38,7 +38,7 @@ class Uast2DocFreq(ToDocFreqBase):
     Calculates document frequencies from models with UASTs.
     """
     MODEL_FROM_CLASS = UASTModel
-    MODEL_TO_CLASS = UASTModel
+    MODEL_TO_CLASS = DocumentFrequencies
 
     def __init__(self, *args, **kwargs):
         super(Uast2DocFreq, self).__init__(*args, **kwargs)

--- a/ast2vec/tests/test_source2bow.py
+++ b/ast2vec/tests/test_source2bow.py
@@ -14,7 +14,7 @@ class Source2DocFreqTests(unittest.TestCase):
             args = argparse.Namespace(
                 processes=2, input=paths.DATA_DIR_SOURCE, output=tmpdir,
                 filter="**/source_*.asdf", vocabulary_size=500,
-                df=os.path.join(os.path.dirname(__file__), paths.DOCFREQ))
+                docfreq=os.path.join(os.path.dirname(__file__), paths.DOCFREQ))
             source2bow_entry(args)
             for n, file in enumerate(os.listdir(tmpdir)):
                 bow = BOW().load(os.path.join(tmpdir, file))


### PR DESCRIPTION
@vmarkovtsev I find several bugs in code.
1. MODEL_TO_CLASS has wrong values in several converters.
2. `source2bow_entry` has no `args.df` because it is `args.docfreq`. You can check it in arg parser.
3. And the last one about the size of the dictionary in `UastModel2BOW`. It was on 1 less than provided and if you provide value less than the number of words, an exception would have been raised.